### PR TITLE
fix: Deploy DB migrations and secrets mounting for staging/production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,9 +66,18 @@ jobs:
       - name: Setup Helm
         uses: azure/setup-helm@v4
 
-      - name: Create namespace if not exists
+      - name: Create namespace and ACR pull secret
         run: |
-          kubectl create namespace ${{ steps.env.outputs.namespace }} --dry-run=client -o yaml | kubectl apply -f -
+          NS=${{ steps.env.outputs.namespace }}
+          kubectl create namespace "${NS}" --dry-run=client -o yaml | kubectl apply -f -
+
+          # Create ACR image pull secret
+          kubectl create secret docker-registry acr-secret \
+            --namespace "${NS}" \
+            --docker-server="${ACR_REGISTRY}" \
+            --docker-username="${{ secrets.ACR_USERNAME }}" \
+            --docker-password="${{ secrets.ACR_PASSWORD }}" \
+            --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Deploy services with Helm
         run: |
@@ -89,6 +98,7 @@ jobs:
               -f "./helm/charts/${service}/values-${ENV}.yaml" \
               --set "image.tag=${TAG}" \
               --set "image.repository=${ACR_REGISTRY}/${service}" \
+              --set "imagePullSecrets[0].name=acr-secret" \
               --timeout 5m
           done
 
@@ -139,6 +149,25 @@ jobs:
             echo "Waiting for ${service}..."
             kubectl rollout status deployment "${service}" -n "${NS}" --timeout=5m || true
           done
+
+      - name: Run database migrations and seed
+        run: |
+          NS=${{ steps.env.outputs.namespace }}
+          ENV=${{ steps.env.outputs.environment }}
+
+          # Run Prisma migrations for services with databases
+          for service in user-service product-service order-service; do
+            echo "Running database migrations for ${service}..."
+            kubectl exec deployment/${service} -n "${NS}" -- npx prisma db push --skip-generate || true
+          done
+
+          # Seed product data only in dev/staging (not production to avoid data loss)
+          if [ "${ENV}" != "production" ]; then
+            echo "Seeding product-service database..."
+            kubectl exec deployment/product-service -n "${NS}" -- npx prisma db seed || true
+          else
+            echo "Skipping seed in production environment"
+          fi
 
       - name: Verify deployment
         run: |

--- a/helm/charts/cart-service/values-production.yaml
+++ b/helm/charts/cart-service/values-production.yaml
@@ -30,3 +30,6 @@ ingress:
 externalSecrets:
   enabled: false
   secretStoreRef: azure-keyvault-production
+
+secrets:
+  REDIS_URL: "placeholder-overridden-by-deploy-workflow"

--- a/helm/charts/cart-service/values-staging.yaml
+++ b/helm/charts/cart-service/values-staging.yaml
@@ -23,3 +23,6 @@ config:
 externalSecrets:
   enabled: false
   secretStoreRef: azure-keyvault-staging
+
+secrets:
+  REDIS_URL: "placeholder-overridden-by-deploy-workflow"

--- a/helm/charts/order-service/values-production.yaml
+++ b/helm/charts/order-service/values-production.yaml
@@ -30,3 +30,8 @@ ingress:
 externalSecrets:
   enabled: false
   secretStoreRef: azure-keyvault-production
+
+secrets:
+  DATABASE_URL: "placeholder-overridden-by-deploy-workflow"
+  SERVICEBUS_CONNECTION_STRING: "placeholder-overridden-by-deploy-workflow"
+  SERVICE_AUTH_TOKEN: "placeholder-overridden-by-deploy-workflow"

--- a/helm/charts/order-service/values-staging.yaml
+++ b/helm/charts/order-service/values-staging.yaml
@@ -23,3 +23,8 @@ config:
 externalSecrets:
   enabled: false
   secretStoreRef: azure-keyvault-staging
+
+secrets:
+  DATABASE_URL: "placeholder-overridden-by-deploy-workflow"
+  SERVICEBUS_CONNECTION_STRING: "placeholder-overridden-by-deploy-workflow"
+  SERVICE_AUTH_TOKEN: "placeholder-overridden-by-deploy-workflow"

--- a/helm/charts/payment-service/values-production.yaml
+++ b/helm/charts/payment-service/values-production.yaml
@@ -30,3 +30,7 @@ ingress:
 externalSecrets:
   enabled: false
   secretStoreRef: azure-keyvault-production
+
+secrets:
+  SERVICEBUS_CONNECTION_STRING: "placeholder-overridden-by-deploy-workflow"
+  SERVICE_AUTH_TOKEN: "placeholder-overridden-by-deploy-workflow"

--- a/helm/charts/payment-service/values-staging.yaml
+++ b/helm/charts/payment-service/values-staging.yaml
@@ -23,3 +23,7 @@ config:
 externalSecrets:
   enabled: false
   secretStoreRef: azure-keyvault-staging
+
+secrets:
+  SERVICEBUS_CONNECTION_STRING: "placeholder-overridden-by-deploy-workflow"
+  SERVICE_AUTH_TOKEN: "placeholder-overridden-by-deploy-workflow"

--- a/helm/charts/product-service/values-production.yaml
+++ b/helm/charts/product-service/values-production.yaml
@@ -30,3 +30,6 @@ ingress:
 externalSecrets:
   enabled: false
   secretStoreRef: azure-keyvault-production
+
+secrets:
+  DATABASE_URL: "placeholder-overridden-by-deploy-workflow"

--- a/helm/charts/product-service/values-staging.yaml
+++ b/helm/charts/product-service/values-staging.yaml
@@ -23,3 +23,6 @@ config:
 externalSecrets:
   enabled: false
   secretStoreRef: azure-keyvault-staging
+
+secrets:
+  DATABASE_URL: "placeholder-overridden-by-deploy-workflow"

--- a/helm/charts/user-service/values-production.yaml
+++ b/helm/charts/user-service/values-production.yaml
@@ -30,3 +30,7 @@ ingress:
 externalSecrets:
   enabled: false
   secretStoreRef: azure-keyvault-production
+
+secrets:
+  DATABASE_URL: "placeholder-overridden-by-deploy-workflow"
+  JWT_SECRET: "placeholder-overridden-by-deploy-workflow"

--- a/helm/charts/user-service/values-staging.yaml
+++ b/helm/charts/user-service/values-staging.yaml
@@ -23,3 +23,7 @@ config:
 externalSecrets:
   enabled: false
   secretStoreRef: azure-keyvault-staging
+
+secrets:
+  DATABASE_URL: "placeholder-overridden-by-deploy-workflow"
+  JWT_SECRET: "placeholder-overridden-by-deploy-workflow"


### PR DESCRIPTION
## Summary

Fixes CrashLoopBackOff on staging/production environments where database-dependent services (user, product, order) had no environment variables.

### Root Cause
Helm charts mount secrets via `envFrom.secretRef` only when `externalSecrets.enabled` or `secrets` is set in values. Staging/production values files had `externalSecrets.enabled: false` and no `secrets:` block, so the condition evaluated to false and no secrets were mounted — even though the deploy workflow creates the k8s secrets via kubectl.

### Changes
1. **Add placeholder secrets** to all staging/production Helm values files so `secretRef` is mounted (deploy workflow overwrites with real values from GitHub Environment secrets)
2. **Add DB migration step** to deploy workflow — runs `prisma db push` + `prisma db seed` for database services
3. **Add ACR pull secret** creation step to deploy workflow

### Files Changed
- `.github/workflows/deploy.yml` — ACR pull secret + DB migration steps
- `helm/charts/*/values-staging.yaml` — placeholder secrets (5 files)
- `helm/charts/*/values-production.yaml` — placeholder secrets (5 files)

### Testing
- Dev environment fully functional with products seeded
- Staging/production will be redeployed after merge