### PR TITLE
feat: enable product seeding in all environments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -176,13 +176,9 @@ jobs:
             kubectl exec deployment/${service} -n "${NS}" -- npx prisma db push --skip-generate || true
           done
 
-          # Seed product data only in dev/staging (not production to avoid data loss)
-          if [ "${ENV}" != "production" ]; then
-            echo "Seeding product-service database..."
-            kubectl exec deployment/product-service -n "${NS}" -- npx prisma db seed || true
-          else
-            echo "Skipping seed in production environment"
-          fi
+          # Seed product data (replaces existing data with fresh catalog)
+          echo "Seeding product-service database..."
+          kubectl exec deployment/product-service -n "${NS}" -- npx prisma db seed || true
 
       - name: Verify deployment
         run: |


### PR DESCRIPTION
## Changes

- Enable product database seeding in all environments (including production)
- Previously seeding was skipped in production to avoid data loss, but since this is a demo app and the seed script clears and re-creates data each run, it is safe for all environments

## Testing
- All 3 environments verified working:
  - Dev: http://9.223.228.173/ ✅
  - Staging: http://135.225.226.74/ ✅
  - Production: http://74.241.197.115/ ✅
