### PR TITLE
fix: use correct Terraform attribute for Redis access key auth

### DIFF
--- a/infrastructure/terraform/modules/redis/main.tf
+++ b/infrastructure/terraform/modules/redis/main.tf
@@ -18,10 +18,13 @@ resource "azurerm_redis_cache" "main" {
   family              = var.family
   sku_name            = var.sku_name
 
-  non_ssl_port_enabled          = false
-  minimum_tls_version           = "1.2"
-  access_key_authentication_enabled = true
-  subnet_id                     = var.sku_name == "Premium" ? var.subnet_id : null
+  non_ssl_port_enabled = false
+  minimum_tls_version  = "1.2"
+  subnet_id            = var.sku_name == "Premium" ? var.subnet_id : null
+
+  redis_configuration {
+    authentication_enabled = true
+  }
 
   tags = var.tags
 }


### PR DESCRIPTION
## Problem

The previous commit (2af5a7d) added `access_key_authentication_enabled` to the Redis Terraform module, but this attribute does not exist in azurerm provider 3.116.0, causing CI terraform validate to fail.

## Root Cause

Access key authentication was disabled on all Azure Redis instances (dev, staging, production), causing `WRONGPASS` errors in cart-service. The initial fix used the wrong Terraform attribute name.

## Fix

- Use the correct attribute: `redis_configuration { authentication_enabled = true }`
- Validated locally with `terraform validate`

## Additional fixes applied (Azure CLI)

- Re-enabled access key auth on all 3 Redis instances
- Added AllowHTTPInbound NSG rule to production AKS NSGs (was missing, causing connection timeouts)

## Verification

- All three environments (dev, staging, production) tested and working
- Cart-service Redis connectivity confirmed with PING/PONG
- Frontend, Products API, Auth, Cart all returning expected responses