### PR TITLE
Fix Terraform drift handling

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -21,6 +21,9 @@ jobs:
     name: 🌍 Terraform ${{ inputs.action }} (${{ inputs.environment }})
     runs-on: ubuntu-latest
     environment: ${{ inputs.action == 'apply' && inputs.environment || '' }}
+    concurrency:
+      group: terraform-tfstate-access
+      cancel-in-progress: false
     defaults:
       run:
         working-directory: infrastructure/terraform/environments/${{ inputs.environment }}
@@ -46,6 +49,45 @@ jobs:
           echo "ARM_TENANT_ID=${{ secrets.AZURE_TENANT_ID }}" >> $GITHUB_ENV
           echo "ARM_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }}" >> $GITHUB_ENV
           echo "ARM_USE_OIDC=true" >> $GITHUB_ENV
+
+      - name: Open Terraform data-plane access
+        run: |
+          set -euo pipefail
+
+          ENV_NAME="${{ inputs.environment }}"
+          ENV_RG="octoeshop-${ENV_NAME}-rg"
+
+          echo "Opening Terraform state backend access..."
+          az storage account update \
+            --resource-group octoeshop-tfstate-rg \
+            --name octoeshoptfstate \
+            --public-network-access Enabled \
+            --default-action Allow \
+            --output none
+
+          if ! az group show --name "$ENV_RG" --output none 2>/dev/null; then
+            echo "Resource group $ENV_RG does not exist yet; skipping environment data-plane access."
+            exit 0
+          fi
+
+          echo "Opening Key Vault data-plane access in $ENV_RG..."
+          for vault in $(az keyvault list --resource-group "$ENV_RG" --query '[].name' --output tsv); do
+            az keyvault update \
+              --name "$vault" \
+              --public-network-access Enabled \
+              --default-action Allow \
+              --output none
+          done
+
+          echo "Opening Storage data-plane access in $ENV_RG..."
+          for account in $(az storage account list --resource-group "$ENV_RG" --query '[].name' --output tsv); do
+            az storage account update \
+              --resource-group "$ENV_RG" \
+              --name "$account" \
+              --public-network-access Enabled \
+              --default-action Allow \
+              --output none
+          done
 
       - name: Configure optional dev Terraform inputs
         if: inputs.environment == 'dev'
@@ -106,6 +148,24 @@ jobs:
       - name: Terraform Apply
         if: inputs.action == 'apply'
         run: terraform apply -auto-approve tfplan
+
+      - name: Reopen Key Vault access for secrets sync
+        if: inputs.action == 'apply'
+        run: |
+          set -euo pipefail
+
+          ENV_RG="octoeshop-${{ inputs.environment }}-rg"
+          if ! az group show --name "$ENV_RG" --output none 2>/dev/null; then
+            exit 0
+          fi
+
+          for vault in $(az keyvault list --resource-group "$ENV_RG" --query '[].name' --output tsv); do
+            az keyvault update \
+              --name "$vault" \
+              --public-network-access Enabled \
+              --default-action Allow \
+              --output none
+          done
 
       - name: Sync secrets to GitHub
         if: inputs.action == 'apply'
@@ -176,3 +236,43 @@ jobs:
           set_kv_secret "jwt-secret" "JWT_SECRET"
 
           echo "✅ Secrets sync complete for $ENV"
+
+      - name: Restore Terraform data-plane restrictions
+        if: always()
+        run: |
+          set -euo pipefail
+
+          ENV_NAME="${{ inputs.environment }}"
+          ENV_RG="octoeshop-${ENV_NAME}-rg"
+
+          echo "Restoring Terraform state backend access restrictions..."
+          az storage account update \
+            --resource-group octoeshop-tfstate-rg \
+            --name octoeshoptfstate \
+            --public-network-access Disabled \
+            --default-action Deny \
+            --output none
+
+          if ! az group show --name "$ENV_RG" --output none 2>/dev/null; then
+            echo "Resource group $ENV_RG does not exist; nothing else to restore."
+            exit 0
+          fi
+
+          echo "Restoring Key Vault data-plane access restrictions in $ENV_RG..."
+          for vault in $(az keyvault list --resource-group "$ENV_RG" --query '[].name' --output tsv); do
+            az keyvault update \
+              --name "$vault" \
+              --public-network-access Disabled \
+              --default-action Deny \
+              --output none
+          done
+
+          echo "Restoring Storage data-plane access restrictions in $ENV_RG..."
+          for account in $(az storage account list --resource-group "$ENV_RG" --query '[].name' --output tsv); do
+            az storage account update \
+              --resource-group "$ENV_RG" \
+              --name "$account" \
+              --public-network-access Disabled \
+              --default-action Deny \
+              --output none
+          done

--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -245,6 +245,11 @@ jobs:
           ENV_NAME="${{ inputs.environment }}"
           ENV_RG="octoeshop-${ENV_NAME}-rg"
 
+          if ! az account show --output none 2>/dev/null; then
+            echo "Azure CLI is not authenticated; skipping data-plane restore."
+            exit 0
+          fi
+
           echo "Restoring Terraform state backend access restrictions..."
           az storage account update \
             --resource-group octoeshop-tfstate-rg \

--- a/docs/cicd-pipeline.md
+++ b/docs/cicd-pipeline.md
@@ -352,11 +352,16 @@ Each environment stores state in the shared Azure Storage Account:
 - Container: `tfstate`
 - Keys: `dev.terraform.tfstate`, `staging.terraform.tfstate`, `production.terraform.tfstate`
 - Authentication: OIDC via Azure AD (no shared keys)
-- Network: GitHub-hosted runners require the storage account public endpoint to
-  be enabled. Access is still restricted by Entra ID/RBAC, shared keys are
-  disabled, and anonymous blob access is disabled. If the backend is moved
-  behind a private endpoint, the Terraform workflow must also move to a
-  private/self-hosted runner with network access to that endpoint.
+- Network: The Terraform backend, environment Key Vaults, and environment
+  storage accounts are kept with public network access disabled after each run.
+  Because the current workflow uses GitHub-hosted runners, `terraform-deploy.yml`
+  temporarily enables public network access for the targeted environment before
+  `terraform init/plan/apply`, then restores public access to disabled and
+  firewall defaults to deny in an `always()` cleanup step.
+  Access is still restricted by Entra ID/RBAC, shared keys are disabled, and
+  anonymous blob access is disabled. If these resources move behind private
+  endpoints, the Terraform workflow must also move to a private/self-hosted
+  runner with network access to those endpoints.
 
 **Optional dev Codespaces private access:**
 

--- a/docs/cicd-pipeline.md
+++ b/docs/cicd-pipeline.md
@@ -311,18 +311,24 @@ graph TD
     B --> C[Azure Login<br/>via OIDC]
     C --> D[Setup Terraform ≥1.5]
     D --> E[Set ARM Environment Variables<br/>OIDC + ARM_USE_OIDC=true]
-    E --> F[terraform init<br/>remote backend in Azure Storage]
-    F --> G[terraform plan -out=tfplan]
-    G --> H{Action = apply?}
-    H -->|Yes| I[terraform apply -auto-approve tfplan]
-    I --> J[Sync Secrets to GitHub<br/>Terraform outputs + Key Vault → gh secret set]
-    J --> K[Cluster Setup<br/>ESO + ingress-nginx + ClusterSecretStore]
-    H -->|No| L[Stop after plan]
+    E --> F[Open Terraform data-plane access<br/>tfstate + env Key Vault/Storage]
+    F --> G[terraform init<br/>remote backend in Azure Storage]
+    G --> H[terraform plan -out=tfplan]
+    H --> I{Action = apply?}
+    I -->|Yes| J[terraform apply -auto-approve tfplan]
+    J --> K[Reopen Key Vault access<br/>for secrets sync]
+    K --> L[Sync Secrets to GitHub<br/>Terraform outputs + Key Vault → gh secret set]
+    L --> M[Cluster Setup<br/>ESO + ingress-nginx + ClusterSecretStore]
+    I -->|No| N[Stop after plan]
+    M --> O[Restore data-plane restrictions<br/>always: public access disabled + default deny]
+    N --> O
 
-    style I fill:#FFCDD2
-    style J fill:#CE93D8
-    style K fill:#80DEEA
-    style L fill:#C8E6C9
+    style F fill:#FFF9C4
+    style J fill:#FFCDD2
+    style L fill:#CE93D8
+    style M fill:#80DEEA
+    style N fill:#C8E6C9
+    style O fill:#FFE0B2
 ```
 
 **Authentication:**

--- a/infrastructure/terraform/environments/dev/main.tf
+++ b/infrastructure/terraform/environments/dev/main.tf
@@ -41,15 +41,16 @@ resource "azurerm_resource_group" "main" {
 module "networking" {
   source = "../../modules/networking"
 
-  project_name           = var.project_name
-  environment            = var.environment
-  location               = var.location
-  resource_group_name    = azurerm_resource_group.main.name
-  vnet_address_space     = var.vnet_address_space
-  aks_subnet_prefix      = var.aks_subnet_prefix
-  database_subnet_prefix = var.database_subnet_prefix
-  redis_subnet_prefix    = var.redis_subnet_prefix
-  tags                   = local.common_tags
+  project_name                           = var.project_name
+  environment                            = var.environment
+  location                               = var.location
+  resource_group_name                    = azurerm_resource_group.main.name
+  vnet_address_space                     = var.vnet_address_space
+  aks_subnet_prefix                      = var.aks_subnet_prefix
+  database_subnet_prefix                 = var.database_subnet_prefix
+  redis_subnet_prefix                    = var.redis_subnet_prefix
+  tags                                   = local.common_tags
+  subnet_default_outbound_access_enabled = true
 
   # When the Codespaces OpenVPN tunnel is enabled, allow inbound 5432 from
   # the P2S client address pool. Wired through the networking module so the
@@ -151,15 +152,16 @@ module "postgresql_order" {
 module "redis" {
   source = "../../modules/redis"
 
-  project_name        = var.project_name
-  environment         = var.environment
-  location            = var.location
-  resource_group_name = azurerm_resource_group.main.name
-  sku_name            = var.redis_sku
-  family              = var.redis_family
-  capacity            = var.redis_capacity
-  subnet_id           = module.networking.redis_subnet_id
-  tags                = local.common_tags
+  project_name                            = var.project_name
+  environment                             = var.environment
+  location                                = var.location
+  resource_group_name                     = azurerm_resource_group.main.name
+  sku_name                                = var.redis_sku
+  family                                  = var.redis_family
+  capacity                                = var.redis_capacity
+  subnet_id                               = module.networking.redis_subnet_id
+  active_directory_authentication_enabled = false
+  tags                                    = local.common_tags
 }
 
 module "servicebus" {

--- a/infrastructure/terraform/environments/production/main.tf
+++ b/infrastructure/terraform/environments/production/main.tf
@@ -127,15 +127,16 @@ module "postgresql_order" {
 module "redis" {
   source = "../../modules/redis"
 
-  project_name        = var.project_name
-  environment         = var.environment
-  location            = var.location
-  resource_group_name = azurerm_resource_group.main.name
-  sku_name            = var.redis_sku
-  family              = var.redis_family
-  capacity            = var.redis_capacity
-  subnet_id           = module.networking.redis_subnet_id
-  tags                = local.common_tags
+  project_name                            = var.project_name
+  environment                             = var.environment
+  location                                = var.location
+  resource_group_name                     = azurerm_resource_group.main.name
+  sku_name                                = var.redis_sku
+  family                                  = var.redis_family
+  capacity                                = var.redis_capacity
+  subnet_id                               = module.networking.redis_subnet_id
+  active_directory_authentication_enabled = true
+  tags                                    = local.common_tags
 }
 
 module "servicebus" {

--- a/infrastructure/terraform/environments/staging/main.tf
+++ b/infrastructure/terraform/environments/staging/main.tf
@@ -127,15 +127,16 @@ module "postgresql_order" {
 module "redis" {
   source = "../../modules/redis"
 
-  project_name        = var.project_name
-  environment         = var.environment
-  location            = var.location
-  resource_group_name = azurerm_resource_group.main.name
-  sku_name            = var.redis_sku
-  family              = var.redis_family
-  capacity            = var.redis_capacity
-  subnet_id           = module.networking.redis_subnet_id
-  tags                = local.common_tags
+  project_name                            = var.project_name
+  environment                             = var.environment
+  location                                = var.location
+  resource_group_name                     = azurerm_resource_group.main.name
+  sku_name                                = var.redis_sku
+  family                                  = var.redis_family
+  capacity                                = var.redis_capacity
+  subnet_id                               = module.networking.redis_subnet_id
+  active_directory_authentication_enabled = true
+  tags                                    = local.common_tags
 }
 
 module "servicebus" {

--- a/infrastructure/terraform/modules/keyvault/main.tf
+++ b/infrastructure/terraform/modules/keyvault/main.tf
@@ -34,6 +34,13 @@ resource "azurerm_key_vault" "main" {
   }
 
   tags = var.tags
+
+  lifecycle {
+    ignore_changes = [
+      network_acls,
+      public_network_access_enabled,
+    ]
+  }
 }
 
 resource "azurerm_role_assignment" "aks_keyvault" {

--- a/infrastructure/terraform/modules/keyvault/main.tf
+++ b/infrastructure/terraform/modules/keyvault/main.tf
@@ -37,7 +37,7 @@ resource "azurerm_key_vault" "main" {
 
   lifecycle {
     ignore_changes = [
-      network_acls,
+      network_acls[0].default_action,
       public_network_access_enabled,
     ]
   }

--- a/infrastructure/terraform/modules/networking/main.tf
+++ b/infrastructure/terraform/modules/networking/main.tf
@@ -103,17 +103,19 @@ resource "azurerm_network_security_group" "redis" {
 }
 
 resource "azurerm_subnet" "aks" {
-  name                 = "${var.project_name}-${var.environment}-aks-subnet"
-  resource_group_name  = var.resource_group_name
-  virtual_network_name = azurerm_virtual_network.main.name
-  address_prefixes     = var.aks_subnet_prefix
+  name                            = "${var.project_name}-${var.environment}-aks-subnet"
+  resource_group_name             = var.resource_group_name
+  virtual_network_name            = azurerm_virtual_network.main.name
+  address_prefixes                = var.aks_subnet_prefix
+  default_outbound_access_enabled = var.subnet_default_outbound_access_enabled
 }
 
 resource "azurerm_subnet" "database" {
-  name                 = "${var.project_name}-${var.environment}-database-subnet"
-  resource_group_name  = var.resource_group_name
-  virtual_network_name = azurerm_virtual_network.main.name
-  address_prefixes     = var.database_subnet_prefix
+  name                            = "${var.project_name}-${var.environment}-database-subnet"
+  resource_group_name             = var.resource_group_name
+  virtual_network_name            = azurerm_virtual_network.main.name
+  address_prefixes                = var.database_subnet_prefix
+  default_outbound_access_enabled = var.subnet_default_outbound_access_enabled
 
   delegation {
     name = "postgresql-flexible-server"
@@ -126,10 +128,11 @@ resource "azurerm_subnet" "database" {
 }
 
 resource "azurerm_subnet" "redis" {
-  name                 = "${var.project_name}-${var.environment}-redis-subnet"
-  resource_group_name  = var.resource_group_name
-  virtual_network_name = azurerm_virtual_network.main.name
-  address_prefixes     = var.redis_subnet_prefix
+  name                            = "${var.project_name}-${var.environment}-redis-subnet"
+  resource_group_name             = var.resource_group_name
+  virtual_network_name            = azurerm_virtual_network.main.name
+  address_prefixes                = var.redis_subnet_prefix
+  default_outbound_access_enabled = var.subnet_default_outbound_access_enabled
 }
 
 resource "azurerm_subnet_network_security_group_association" "aks" {

--- a/infrastructure/terraform/modules/networking/variables.tf
+++ b/infrastructure/terraform/modules/networking/variables.tf
@@ -49,3 +49,9 @@ variable "database_additional_allow_postgres_source_cidrs" {
   type        = list(string)
   default     = []
 }
+
+variable "subnet_default_outbound_access_enabled" {
+  description = "Whether Azure should provide default outbound access for subnets. Existing dev subnets still use Azure's legacy enabled default, while staging and production have it disabled."
+  type        = bool
+  default     = false
+}

--- a/infrastructure/terraform/modules/redis/main.tf
+++ b/infrastructure/terraform/modules/redis/main.tf
@@ -11,19 +11,21 @@ locals {
 }
 
 resource "azurerm_redis_cache" "main" {
-  name                = local.cache_name
-  location            = var.location
-  resource_group_name = var.resource_group_name
-  capacity            = var.capacity
-  family              = var.family
-  sku_name            = var.sku_name
+  name                               = local.cache_name
+  location                           = var.location
+  resource_group_name                = var.resource_group_name
+  capacity                           = var.capacity
+  family                             = var.family
+  sku_name                           = var.sku_name
+  access_keys_authentication_enabled = var.access_keys_authentication_enabled
 
   non_ssl_port_enabled = false
   minimum_tls_version  = "1.2"
   subnet_id            = var.sku_name == "Premium" ? var.subnet_id : null
 
   redis_configuration {
-    authentication_enabled = true
+    active_directory_authentication_enabled = var.active_directory_authentication_enabled
+    authentication_enabled                  = true
   }
 
   tags = var.tags

--- a/infrastructure/terraform/modules/redis/variables.tf
+++ b/infrastructure/terraform/modules/redis/variables.tf
@@ -40,6 +40,18 @@ variable "subnet_id" {
   nullable    = true
 }
 
+variable "access_keys_authentication_enabled" {
+  description = "Whether Redis access key authentication is enabled. Keep enabled while application configuration is distributed as a Redis access-key connection string."
+  type        = bool
+  default     = true
+}
+
+variable "active_directory_authentication_enabled" {
+  description = "Whether Microsoft Entra authentication is enabled for Redis."
+  type        = bool
+  default     = true
+}
+
 variable "tags" {
   description = "Resource tags"
   type        = map(string)

--- a/infrastructure/terraform/modules/servicebus/main.tf
+++ b/infrastructure/terraform/modules/servicebus/main.tf
@@ -11,11 +11,13 @@ locals {
 }
 
 resource "azurerm_servicebus_namespace" "main" {
-  name                = local.namespace_name
-  location            = var.location
-  resource_group_name = var.resource_group_name
-  sku                 = var.sku
-  tags                = var.tags
+  name                          = local.namespace_name
+  location                      = var.location
+  resource_group_name           = var.resource_group_name
+  sku                           = var.sku
+  local_auth_enabled            = true
+  public_network_access_enabled = true
+  tags                          = var.tags
 }
 
 resource "azurerm_servicebus_queue" "order_created" {

--- a/infrastructure/terraform/modules/storage/main.tf
+++ b/infrastructure/terraform/modules/storage/main.tf
@@ -32,6 +32,13 @@ resource "azurerm_storage_account" "main" {
   }
 
   tags = var.tags
+
+  lifecycle {
+    ignore_changes = [
+      network_rules,
+      public_network_access_enabled,
+    ]
+  }
 }
 
 resource "azurerm_storage_container" "product_images" {

--- a/infrastructure/terraform/modules/storage/main.tf
+++ b/infrastructure/terraform/modules/storage/main.tf
@@ -31,11 +31,18 @@ resource "azurerm_storage_account" "main" {
     }
   }
 
+  network_rules {
+    default_action             = "Allow"
+    bypass                     = ["AzureServices"]
+    ip_rules                   = []
+    virtual_network_subnet_ids = []
+  }
+
   tags = var.tags
 
   lifecycle {
     ignore_changes = [
-      network_rules,
+      network_rules[0].default_action,
       public_network_access_enabled,
     ]
   }


### PR DESCRIPTION
## Summary
- Add controlled GitHub Actions data-plane open/restore handling for Terraform state, environment Key Vaults, and app storage accounts.
- Encode observed Azure defaults for subnet outbound access, Redis auth, and Service Bus local auth to reduce unintended drift.
- Keep Codespaces VPN/DB-access resources disabled and document the secure data-plane workflow behavior.

## Validation
- terraform fmt -check -recursive infrastructure/terraform
- terraform validate for dev, staging, and production with backend disabled
- workflow YAML parsing for terraform-deploy, infrastructure, and CI workflows
- git diff --check
- Three parallel review agents ran; actionable findings were addressed.

## Note
Branch workflow_dispatch Terraform validation is blocked by Azure OIDC federation for refs/heads/fix/terraform-drift-secure-defaults. The workflow now skips restore safely if Azure login fails, and PR/main/environment-based validation should use the configured federated subjects.