### PR TITLE
Fix canonical/OG URLs to match the Pages host

### DIFF
--- a/demo-site/astro.config.mjs
+++ b/demo-site/astro.config.mjs
@@ -5,7 +5,7 @@ import expressiveCode from 'astro-expressive-code';
 // Fully custom site — no Starlight. Astro + MDX for content, Expressive Code
 // for GitHub-themed syntax highlighting with a built-in copy button.
 export default defineConfig({
-  site: 'https://edinc.github.io',
+  site: 'https://codecurrent-sandbox.github.io',
   base: '/octo-eshop-demo',
   trailingSlash: 'ignore',
   integrations: [


### PR DESCRIPTION
## Problem

The demo site deploys to **`codecurrent-sandbox.github.io/octo-eshop-demo/`**, but `demo-site/astro.config.mjs` still had `site: 'https://edinc.github.io'` (inherited from the original Starlight config). As a result the deployed pages emitted a `<link rel="canonical">` and `og:url` pointing at `https://edinc.github.io/octo-eshop-demo/`, which 404s.

## Fix

Set `site` to `https://codecurrent-sandbox.github.io` so canonical and Open Graph URLs resolve to the real host.

- `base: '/octo-eshop-demo'` was already correct, so navigation, assets, and the favicon were never affected — this is metadata/SEO only.
- Verified in the production build: `<link rel="canonical">` and `og:url` now read `https://codecurrent-sandbox.github.io/octo-eshop-demo/`.
- Build passes (14 pages); `astro.config.mjs` passes prettier.

## Note

In-content links to `github.com/edinc/octo-eshop-demo` and `codespaces.new/edinc/octo-eshop-demo` are left as-is — GitHub redirects the old owner to the current repo, so they resolve correctly. Happy to update those too if preferred.